### PR TITLE
fix(Mana): correct IsRetailWoW typo to IsRetailWow

### DIFF
--- a/Statuses/Mana.lua
+++ b/Statuses/Mana.lua
@@ -113,7 +113,7 @@ function PlexusStatusMana:UpdateUnit(event, unit)
         local cur = UnitPower(unit, 0)
         local max = UnitPowerMax(unit, 0)
         local settings = self.db.profile.alert_lowMana
-        if Plexus:IsRetailWoW() then
+        if Plexus:IsRetailWow() then
                 return PlexusStatus:SendStatusGained(guid, "alert_lowMana",
                     settings.priority,
                     settings.range,


### PR DESCRIPTION
## Problem                                                                                                                                                                                                     
                                                                                                                                                                                                                
On Classic Anniversary (Interface 20505), loading Plexus causes this error:                                                                                                                                    
                                                                                                                                                                                                                
Interface/AddOns/Plexus/Statuses/Mana.lua:116: attempt to call method 'IsRetailWoW' (a nil value)                                                                                                              
                                                                                                                                                                                                                
## Cause                                                                                                                                                                                                       
                                                                                                                                                                                                                
Line 116 of `Statuses/Mana.lua` calls `Plexus:IsRetailWoW()` but the method is defined as `Plexus:IsRetailWow()` in `Core.lua:69`. Lua is case-sensitive, so this is a nil method call.                        
                                                                                                                                                                                                                
Line 15 of the same file uses the correct casing (`IsRetailWow`), so this is just a typo on line 116.                                                                                                          
                                                                                                                                                                                                                
## Fix                                                                                                                                                                                                         
                                                                                                                                                                                                                
Change `IsRetailWoW` to `IsRetailWow` on line 116 to match the method definition. 